### PR TITLE
G4PeriodicBoundaryProcess: added G4Navigator::ComputeSafety() call

### DIFF
--- a/src/G4PeriodicBoundaryProcess.cc
+++ b/src/G4PeriodicBoundaryProcess.cc
@@ -228,6 +228,7 @@ G4PeriodicBoundaryProcess::PostStepDoIt(const G4Track& aTrack, const G4Step& aSt
                                                 &NewMomentum,
                                                true,
                                                false) ;//do not ignore direction
+          gNavigator->ComputeSafety(NewPosition);
 
 
           //force drawing of the step prior to periodic the particle


### PR DESCRIPTION
This is to update the navigator's safety calculations after moving the particle